### PR TITLE
DM-15872: Incorporate AP documentation into pipelines.lsst.io

### DIFF
--- a/doc/ap_verify_testdata/index.rst
+++ b/doc/ap_verify_testdata/index.rst
@@ -5,7 +5,7 @@ ap_verify_testdata
 ##################
 
 The ``ap_verify_testdata`` package contains several files from `obs_test <https://github.com/lsst/obs_test/>`_.
-The package is intended to test dataset support in `lsst.ap.verify` code.
+The package is intended to test dataset support in :doc:`/modules/lsst.ap.verify/index` code.
 
 .. _ap_verify_testdata-using:
 

--- a/doc/ap_verify_testdata/index.rst
+++ b/doc/ap_verify_testdata/index.rst
@@ -5,20 +5,19 @@ ap_verify_testdata
 ##################
 
 The ``ap_verify_testdata`` package contains several files from `obs_test <https://github.com/lsst/obs_test/>`_.
-The package is intended to test dataset support in ``ap_verify`` code.
+The package is intended to test dataset support in `lsst.ap.verify` code.
 
-Project info
-============
+.. _ap_verify_testdata-using:
 
-Repository
-   https://github.com/lsst-dm/ap_verify_testdata
+Using ap_verify_testdata
+========================
 
-.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+This package provides a minimal valid dataset for testing dataset handling, particularly ingestion.
+Because there are no templates and the reference catalog is not guaranteed to match the data, this dataset is not suitable for full ``ap_verify`` runs.
 
-Jira component
-   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "testdata">`_
+.. _ap_verify_testdata-contents:
 
-Dataset Contents
+Dataset contents
 ================
 
 This package provides a number of demonstration files copied from `obs_test <https://github.com/lsst/obs_test/>`_.
@@ -28,8 +27,15 @@ The dataset contents include raw images, biases, flats, and defects.
 The dataset does not provide any image differencing templates.
 It does have a small Gaia DR1 reference catalog, but it is not guaranteed to overlap with the footprint of the raw data.
 
-Intended Use
+.. _ap_verify_testdata-contributing:
+
+Contributing
 ============
 
-This package provides a minimal valid dataset for testing dataset handling, particularly ingestion.
-Because there are no templates and the reference catalog is not guaranteed to match the data, this dataset is not suitable for full ``ap_verify`` runs.
+``ap_verify_testdata`` is developed at https://github.com/lsst/ap_verify_testdata.
+You can find Jira issues for this module under the `ap_verify <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify%20AND%20text~"testdata">`_ component.
+
+.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
+
+.. .. toctree::
+..    :maxdepth: 1

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -4,13 +4,8 @@
 # Also the name of the package documentation subdirectory.
 package: "ap_verify_testdata"
 
-# List of names of Python modules in this package.
-# For each module there is a corresponding module doc subdirectory.
-# modules:
-#   - "lsst.ap.verify.testdata"
-
 # Name of the static content directories (subdirectories of `_static`).
 # Static content directories are usually named after the package.
+# Most packages do not need a static content directory (leave commented out).
 # statics:
 #   - "_static/ap_verify_testdata"
-


### PR DESCRIPTION
This PR updates the documentation to current data package conventions and fixes build errors detected when building with `pipelines_lsst_io`. Note that this documentation is not currently being built by pipelines.lsst.io (to avoid having to download the entire package), so it may bitrot in the future.