### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -8,6 +8,6 @@ obsDir = os.path.join(getPackageDir('obs_lsst'), 'config')
 config.dataIngester.load(os.path.join(obsDir, 'ingest.py'))
 config.dataIngester.load(os.path.join(obsDir, 'imsim', 'ingest.py'))
 config.calibIngester.load(os.path.join(obsDir, 'ingestCalibs.py'))
-config.defectIngester.load(os.path.join(obsDir, 'ingestCuratedCalibs.py'))
+config.curatedCalibIngester.load(os.path.join(obsDir, 'ingestCuratedCalibs.py'))
 
 config.refcats = {'gaia': 'gaia_example.tar.gz'}


### PR DESCRIPTION
This PR edits `datasetIngest.py` for the changes made to `DatasetIngestConfig` in lsst/ap_verify#91.