### PR TITLE
DM-24575: Add observational and detector metadata to Registry dimension tables

### DIFF
--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa901cff75de141ff2142ca2bd602d89dd2edc0dcf7d6b11c281308621a73431
+oid sha256:0e7bf243b2db87187a17d13c88e36405e2fd651a634a47809fb0bf12bf3f70c0
 size 573440

--- a/scripts/add_gen3_repo.py
+++ b/scripts/add_gen3_repo.py
@@ -115,12 +115,12 @@ def _export_for_copy(dataset, repo):
     butler = daf_butler.Butler(repo)
     with butler.export(directory=dataset.configLocation, format="yaml") as contents:
         # Need all detectors, even those without data, for visit definition
-        contents.saveDataIds(butler.registry.queryDimensions({"detector"}))
+        contents.saveDataIds(butler.registry.queryDataIds({"detector"}).expanded())
         # RepoExport has no safeguards against redundant data
         extraDimensions = set(butler.registry.dimensions.elements).difference(
             {"detector", "instrument", "htm7", "abstract_filter"}
         )
-        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=..., expand=True),
+        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=...),
                               elements=extraDimensions)
 
 


### PR DESCRIPTION
This PR updates the Gen 3 repository in `ap_verify_testdata` to match the registry changes in DM-24575, after fixing some API incompatibilities in the conversion script.