### PR TITLE
DM-26326: Remove obs dependency from ap_verify_testdata and ap_pipe_testdata

### DIFF
--- a/ups/ap_verify_testdata.table
+++ b/ups/ap_verify_testdata.table
@@ -1,1 +1,2 @@
-setupRequired(obs_lsst)
+# Data cannot be used without obs_lsst, but this dependency is omitted to
+# avoid forcing a new download any time obs_lsst is rebuilt.


### PR DESCRIPTION
This PR removes the sole EUPS dependency from this package.