### PR TITLE
DM-26140: Centralize Gen 3 pipeline configuration info for ap_verify datasets

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -1,0 +1,7 @@
+description: End to end Alert Production pipeline for test dataset
+#
+# This pipeline delegates to per-task config files to ensure consistency with Gen 2.
+# The config files can be merged into this once ap_verify no longer supports Gen 2.
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipe.yaml

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -1,0 +1,11 @@
+description: Instrumented Alert Production pipeline for test dataset
+#
+# This pipeline delegates to per-task config files to ensure consistency with Gen 2.
+# The config files can be merged into this once ap_verify no longer supports Gen 2.
+#
+# This pipeline does not depend on the local ApPipe.yaml, because the definition
+# of the primary ApVerify.yaml is more likely to change than the data-specific
+# overrides, and importing both pipelines can't merge changes to the same task.
+
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/LsstCamImSim/ApVerify.yaml


### PR DESCRIPTION
This PR adds dummy pipeline overrides to the dataset, so that tests can verify that the `ap_verify` framework handles pipeline specializations correctly.