### PR TITLE
DM-32261: Fix definition of LSSTCam-imSim/defaults.

### DIFF
--- a/config/export.yaml
+++ b/config/export.yaml
@@ -1232,6 +1232,7 @@ data:
   collection_type: CHAINED
   name: LSSTCam-imSim/defaults
   children:
+  - templates/goodSeeing
   - LSSTCam-imSim/calib
   - skymaps
   - refcats

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e98d063a41e6142720488acdc9cf580d0a538b91b023be543c58eb28bbc0e1c3
+oid sha256:56f0279714eed60f086e4f78d8e147c100aa9edfc51716ae427c04fe18aec279
 size 594644992


### PR DESCRIPTION
The collection did not include the templates added in #33.