### PR TITLE
DM-37667: Migrate preloaded repo to latest versions.

### DIFF
--- a/config/export.yaml
+++ b/config/export.yaml
@@ -1,11 +1,14 @@
 description: Butler Data Repository Export
-version: 1.0.1
+version: 1.0.2
+universe_version: 3
+universe_namespace: daf_butler
 data:
 - type: dimension
   element: instrument
   records:
   - name: LSSTCam-imSim
     visit_max: 9999999
+    visit_system: 0
     exposure_max: 9999999
     detector_max: 1000
     class_name: lsst.obs.lsst.LsstCamImSim

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56f0279714eed60f086e4f78d8e147c100aa9edfc51716ae427c04fe18aec279
-size 594644992
+oid sha256:a12678c49bf0be1382fb7446a6bb15db91ab41d37ac33bad6e0621c2ce7046bd
+size 594694144


### PR DESCRIPTION
This PR migrates the preloaded repo to current schemas, to prevent the kinds of compatibility problems that interfered with adding ephemerides on lsst/ap_verify_ci_cosmos_pdr2#32.