### PR TITLE
DM-42217: Incorporate ModelPackage Butler datasets into ap_verify

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.gz filter=lfs diff=lfs merge=lfs -text
 *.fz filter=lfs diff=lfs merge=lfs -text
 *.sqlite3 filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,5 +2,5 @@
 
 ****
 
-- [ ] Did you run `ap_verify.py` on this dataset?
+- [ ] Did you run `ap_verify`'s unit tests with this dataset set up?
 - [ ] Are the Sphinx documentation and readme up-to-date?

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ path                  | description
 :---------------------|:-----------------------------
 `raw`                 | Raw fits files from [`testdata_lsst`](https://github.com/lsst/testdata_lsst/tree/master/data) in `i` band.
 `config`              | Dataset-specific configs to help Stack code work with this dataset.
-`preloaded`           | A Gen 3 Butler repository containing master calibration files from `lsst-dev:/datasets/DC2/repoRun2.2i` for `i` band, a token `goodSeeing` template, and a small Gaia reference catalog.
+`preloaded`           | A Gen 3 Butler repository containing master calibration files from `lsst-dev:/datasets/DC2/repoRun2.2i` for `i` band, a token `goodSeeing` template, a small Gaia reference catalog, and a dummy real/bogus classification model.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
 
 

--- a/config/export.yaml
+++ b/config/export.yaml
@@ -1210,6 +1210,12 @@ data:
   timespan_end: null
 - type: collection
   collection_type: RUN
+  name: pretrained_models/dummy
+  host: null
+  timespan_begin: null
+  timespan_end: null
+- type: collection
+  collection_type: RUN
   name: refcats/gen2
   host: null
   timespan_begin: null
@@ -1228,6 +1234,11 @@ data:
   timespan_end: null
 - type: collection
   collection_type: CHAINED
+  name: models
+  children:
+  - pretrained_models/dummy
+- type: collection
+  collection_type: CHAINED
   name: refcats
   children:
   - refcats/gen2
@@ -1239,6 +1250,7 @@ data:
   - LSSTCam-imSim/calib
   - skymaps
   - refcats
+  - models
 - type: dataset_type
   name: bfk
   dimensions:
@@ -2702,6 +2714,21 @@ data:
       patch: 0
     path: templates/goodSeeing/goodSeeingCoadd/0/0/i/goodSeeingCoadd_0_0_i_test-skymap_templates_goodSeeing.fits
     formatter: lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter
+- type: dataset_type
+  name: pretrainedModelPackage
+  dimensions: []
+  storage_class: NNModelPackagePayload
+  is_calibration: false
+- type: dataset
+  dataset_type: pretrainedModelPackage
+  run: pretrained_models/dummy
+  records:
+  - dataset_id:
+    - !uuid '0f86424e-6b5a-4ab7-b632-ebd77c4eb4e0'
+    data_id:
+    - {}
+    path: pretrained_models/dummy/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_dummy.zip
+    formatter: lsst.meas.transiNet.modelPackages.formatters.NNModelPackageFormatter
 - type: dataset_type
   name: skyMap
   dimensions:

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a12678c49bf0be1382fb7446a6bb15db91ab41d37ac33bad6e0621c2ce7046bd
-size 594694144
+oid sha256:497f5d2d4b669bc90206b004d52bd94465f14d9d61a8b60ba7deb9f122527fc2
+size 594706432

--- a/preloaded/pretrained_models/dummy/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_dummy.zip
+++ b/preloaded/pretrained_models/dummy/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_dummy.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd9276de52b4c57254ad01184d373db8ac039e54214732df61bfd102f6fbca7f
+size 29505991

--- a/scripts/get_nn_models.py
+++ b/scripts/get_nn_models.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_dataset_template.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for ingesting pretrained neural net models for this dataset.
+
+Running this script allows for updates or replacements of the existing model.
+
+Example:
+$ python get_nn_models.py -m rbResnet50-DC2
+imports rbResnet50-DC2 from /repo/main to this dataset's preloaded repo. See
+get_nn_models.py -h for more options.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+from lsst.meas.transiNet.modelPackages.storageAdapterButler import StorageAdapterButler
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+MODEL_PREFIX = StorageAdapterButler.packages_parent_collection
+MODEL_CHAIN = "models"
+
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATASET_REPO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Repo to import from, defaults to '/repo/main'.")
+    parser.add_argument("-m", dest="model_name", required=True,
+                        help="Model package to import.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Clean up existing model
+
+def _clean_dataset(butler):
+    """Remove the previous model(s), to avoid clashes on load.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository to be cleaned.
+    """
+    try:
+        model_runs = butler.registry.getCollectionChain(MODEL_CHAIN)
+    except lsst.daf.butler.registry.MissingCollectionError:
+        # No prior collections
+        return
+
+    butler.registry.setCollectionChain(MODEL_CHAIN, [])
+    butler.removeRuns(model_runs, unstore=True)
+
+
+dest = Butler(DATASET_REPO, writeable=True)
+_clean_dataset(dest)
+
+
+########################################
+# Transfer
+
+MODEL_COLLECT = f"{MODEL_PREFIX}/{args.model_name}"
+
+src = Butler(args.src_dir, writeable=False)
+dest.transfer_from(src, src.registry.queryDatasets(..., collections=MODEL_COLLECT),
+                   transfer="copy", register_dataset_types=True)
+
+dest.registry.registerCollection(MODEL_CHAIN, CollectionType.CHAINED)
+dest.registry.setCollectionChain(MODEL_CHAIN, [MODEL_COLLECT])
+
+logging.info(f"Model {args.model_name} stored in {DATASET_REPO}:{MODEL_CHAIN}.")


### PR DESCRIPTION
This PR adds a dummy real/bogus model, as well as a script for regenerating or replacing it in the future. This increases the download size from 808 MiB to 836 MiB.

****

- [X] Did you run `ap_verify`'s unit tests with this dataset set up?
- [X] Are the Sphinx documentation and readme up-to-date?
