### PR TITLE
DM-41163: Add checklist item for avoiding bitrot in scripts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,6 @@
 ****
 
 - [ ] Did you run `ap_verify`'s unit tests with this dataset set up?
+- [ ] If you updated the data, have the maintenance scripts in `scripts/` been updated to match?
 - [ ] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
 - [ ] Are the Sphinx documentation and readme up-to-date?


### PR DESCRIPTION
This PR adds a checklist item for making sure that the data set maintenance scripts create the data set in its current form, and not an older version.